### PR TITLE
add setuptools_scm for versioning and manifest, fixes #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ MANIFEST
 .coverage
 .coverage.*
 htmlcov
+flatland/_version.py
 tests/cover
 build
 dist

--- a/.hgignore
+++ b/.hgignore
@@ -5,6 +5,7 @@ syntax: glob
 MANIFEST
 .coverage
 htmlcov
+flatland/_version.py
 tests/cover
 build
 dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,7 @@
-include LICENSE
-include README
-include AUTHORS
-recursive-include tests *py
-recursive-include docs/source *rst *py
+# stuff we need to include into the sdist is handled automatically by
+# setuptools_scm - it includes all git-committed files.
+# but we want to exclude some committed files/dirs not needed in the sdist:
+exclude .gitattributes .gitignore .hgignore .travis.yml
+recursive-include flatland *.mo
 recursive-include docs/text *txt
 recursive-include docs/html *html *txt *png *css *js *inv
-recursive-include flatland *.mo *.po *.pot

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,8 +1,14 @@
 project = u'flatland'
 copyright = u'2008-2018, the flatland authors and contributors'
 
-version = '0.0'
-release = '0.0.git-master'
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+import sys, os
+sys.path.insert(0, os.path.abspath('../..'))
+
+from flatland._version import version
+release = version
 
 
 master_doc = 'index'

--- a/flatland/__init__.py
+++ b/flatland/__init__.py
@@ -84,4 +84,4 @@ __all__ = [
     'validator_validated',
     ]
 
-__version__ = '0.8'
+from ._version import version as __version__

--- a/setup.py
+++ b/setup.py
@@ -19,15 +19,10 @@ except ImportError:
                 for w in os.walk('flatland')
                 if '__init__.py' in w[2]]
 
-# note: importing flatland so we can use flatland.__version__ here does
-# NOT work at package installation time - it falls over the blinker import.
-# thus, until this is fixed, we duplicate the version number here:
-version = '0.8'
 
 long_desc = open('README').read()
 
 setup(name="flatland",
-      version=version,
       packages=find_packages(exclude=['tests.*', 'tests']),
       author='Jason Kirtland',
       author_email='jek@discorporate.us',
@@ -46,7 +41,13 @@ setup(name="flatland",
                    'Programming Language :: Python :: 2.7',
                    'Topic :: Internet :: WWW/HTTP :: WSGI',
                    'Topic :: Software Development :: Libraries'],
+      use_scm_version={
+          'write_to': 'flatland/_version.py',
+      },
+      setup_requires=[
+          'setuptools_scm',
+      ],
       install_requires=[
           'blinker',
-          ],
+      ],
       **extra_setup)


### PR DESCRIPTION
versioning:
- `flatland.__version__`
- sphinx docs version
- pypi package version

manifest: automatically handles the usual case when a committed file shall go into the pypi package, so we only need to care for special cases.