### PR TITLE
Makefile: remove version related code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-TIP=$(shell git rev-list HEAD | head -1)
 SOURCES=$(shell find flatland -name '*.py')
 I18N=flatland/i18n
 
@@ -18,14 +17,8 @@ compile-messages:
 	pybabel compile -d $(I18N) -D flatland
 
 tip-sdist: compile-messages
-	@echo "Preparing sdist of flatland @ git.$(TIP)"
-	perl -pi -e \
-          "s~version = flatland.__version__~version = 'git.$(TIP)'~" \
-          setup.py
+	@echo "Preparing sdist of flatland..."
 	(cd docs/source && make clean)
-	(cd docs/source && VERSION=$(TIP) make html)
-	(cd docs/source && VERSION=$(TIP) make text)
+	(cd docs/source && make html)
+	(cd docs/source && make text)
 	python setup.py sdist
-	perl -pi -e \
-          "s~version = 'git.$(TIP)'~version = flatland.__version__~" \
-          setup.py

--- a/docs/source/Makefile
+++ b/docs/source/Makefile
@@ -4,7 +4,6 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-VERSION      ?= tip
 
 # Internal variables.
 ALLSPHINXOPTS = -d ../doctrees $(SPHINXOPTS) .
@@ -39,7 +38,6 @@ website:
 	mkdir -p ../website ../doctrees
 	$(SPHINXBUILD) -b discorporate \
            -D html_theme=discorporate \
-           -D version=$(VERSION) \
            $(ALLSPHINXOPTS) ../website
 
 doctest:


### PR DESCRIPTION
it is handled by setuptools_scm now (output: flatland/_version.py) and the sphinx conf.py imports that generated version, so we do not need to give it via $VERSION env var.

I could not test the "website" target as it misses a "discorporate" builder.