### PR TITLE
only give a list to _set_flat()

### DIFF
--- a/flatland/schema/base.py
+++ b/flatland/schema/base.py
@@ -638,7 +638,7 @@ class Element(object):
         if hasattr(pairs, 'items'):
             pairs = pairs.items()
 
-        return self._set_flat(pairs, sep)
+        return self._set_flat(list(pairs), sep)
 
     def _set_flat(self, pairs, sep):
         raise NotImplementedError()


### PR DESCRIPTION
when giving a generator (or iterator) to _set_flat(),
it might malfunction as it might try to fully iterate it more than once.

with python 3, a generator is returned from pairs.items() [directly
above the fixed line], thus set_flat() might malfunction when a dict
is given to it (instead of a list of pairs).