### PR TITLE
SetWithKnownFields: fix failing doctest, fixes #25

### DIFF
--- a/src/flatland/validation/containers.py
+++ b/src/flatland/validation/containers.py
@@ -318,22 +318,6 @@ class SetWithKnownFields(Validator):
       from flatland import Dict, Integer
       from flatland.validation import SetWithKnownFields
 
-      schema = Dict.of(Integer.named('x'), Integer.named('y')).\\
-                    validated_by(SetWithKnownFields())
-      schema.policy = None
-      element = schema()
-
-      element.set({'x': 123, 'y': 456})
-      assert element.validate()
-
-      element.set({'x': 123, 'y': 456, 'z': 789})
-      assert not element.validate()
-
-    .. testcode::
-
-      from flatland import Dict, Integer
-      from flatland.validation import SetWithKnownFields
-
       Int = Integer.using(optional=True)
       schema = Dict.of(Int.named('x'), Int.named('y')).\\
                     validated_by(SetWithKnownFields())


### PR DESCRIPTION
One of the SetWithKnownFields doctests was incorrect.

SetWithKnownFields deals with unexpected fields, while requiredness is handled by the schema elements themselves.

The doctest used Integer fields which are required by default, but the doctest did not set all the required fields.

This updates the doctest to explicitly make the fields optional using `Integer.using(optional=True)`, allowing the validation to pass as intended if not all fields are set, while still failing the validation if unknown fields are set.